### PR TITLE
Add settings

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,94 @@
+[
+    {
+        "id": "preferences",
+        "children": [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children": [
+                    {
+                        "caption": "Resize Group With Keyboard",
+                        "children": [
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/SublimeResizeGroupWithKeyboard/README.md",
+                                    "platform": "Windows"
+                                },
+                                "caption": "Help"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/SublimeResizeGroupWithKeyboard/README.md",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Help"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/SublimeResizeGroupWithKeyboard/README.md",
+                                    "platform": "Linux"
+                                },
+                                "caption": "Help"
+                            },
+                            {
+                              "caption": "-"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/SublimeResizeGroupWithKeyboard/resize_active_group.sublime-settings",
+                                    "platform": "Windows"
+                                },
+                                "caption": "Settings - Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/SublimeResizeGroupWithKeyboard/resize_active_group.sublime-settings",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Settings - Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/SublimeResizeGroupWithKeyboard/resize_active_group.sublime-settings",
+                                    "platform": "Linux"
+                                },
+                                "caption": "Settings - Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/resize_active_group.sublime-settings",
+                                    "platform": "Windows"
+                                },
+                                "caption": "Settings - User"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/resize_active_group.sublime-settings",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Settings - User"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/resize_active_group.sublime-settings",
+                                    "platform": "Linux"
+                                },
+                                "caption": "Settings - User"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/README.md
+++ b/README.md
@@ -20,3 +20,29 @@ Sublime Text 2 and 3 Plugin to resize active group with keyboard
  * Press ctrl-alt-down to shrink active group vertically.
 
 ![Plugin in action](Screenshots/Demo.gif)
+
+## Settings
+The settings are stored under 
+`Preferences / Package Settings / Resize Group With Keyboard / Settings - Default`.
+In order to change the default settings, copy the settings to `Settings - Default` 
+found under the same menu, and edit their values.
+
+### Setting the resize delta
+The resize delta is set to 0.01 by default, similar to 1 % of the entire application window.
+Change this to a greater or a smaller value in order to resize the groups accordingly.
+```JSON
+{ "resize_delta_default": 0.01 }
+```
+
+### Per-direction resizing
+Optionally, the resize deltas can be set explicitly for each of the directions.
+This can be handy you want different resizing with e.g. Up/Down and Left/Right.
+For example:
+```JSON
+{
+  "resize_delta_up": 0.01,
+  "resize_delta_down": 0.01,
+  "resize_delta_left": 0.1,
+  "resize_delta_right": 0.1
+}
+```

--- a/resize_active_group.py
+++ b/resize_active_group.py
@@ -1,5 +1,28 @@
 import sublime, sublime_plugin
 
+settings_file = "resize_active_group.sublime-settings"
+settings = None
+
+# Loads the settings specified by 'settings_file' and adds a callback to be called every time
+# the 'settings_file' changes.
+def plugin_loaded():
+	global settings
+
+	settings = sublime.load_settings(settings_file)
+	settings.add_on_change(settings_file, load_deltas)
+	load_deltas()
+
+# Loads the four different delta values used by the 'ResizeActiveGroupCommand'.
+# It is called by 'plugin_loaded' and every time the 'settings_file' changes.
+def load_deltas():
+	global delta_up, delta_down, delta_left, delta_right
+
+	delta_default = settings.get("delta_default", 0.1)
+	delta_up = settings.get("delta_up", delta_default)
+	delta_down = settings.get("delta_down", delta_default)
+	delta_left = settings.get("delta_left", delta_default)
+	delta_right = settings.get("delta_right", delta_default)
+
 XMIN, YMIN, XMAX, YMAX = range(4)
 
 class ResizeActiveGroupCommand(sublime_plugin.WindowCommand):
@@ -22,19 +45,19 @@ class ResizeActiveGroupCommand(sublime_plugin.WindowCommand):
 		if direction == 'up':
 			items = rows
 			index = cell[YMAX]
-			delta = -0.01
+			delta = -delta_up
 		if direction == 'down':
 			items = rows
 			index = cell[YMAX]
-			delta = 0.01
+			delta = delta_down
 		if direction == 'left':
 			items = cols
 			index = cell[XMAX]
-			delta = -0.01
+			delta = -delta_left
 		if direction == 'right':
 			items = cols
 			index = cell[XMAX]
-			delta = 0.01
+			delta = delta_right
 
 		if len(items) == 2:
 			return
@@ -46,3 +69,8 @@ class ResizeActiveGroupCommand(sublime_plugin.WindowCommand):
 
 		layout =  {"cols": cols, "rows": rows, "cells": cells}
 		self.window.set_layout(layout)
+
+# The 'plugin_loaded' is automatically called by ST3 when the API is ready.
+# If we're using ST2, it has to be called explicitly.
+if not int(sublime.version()) > 3000:
+	plugin_loaded()

--- a/resize_active_group.py
+++ b/resize_active_group.py
@@ -17,11 +17,11 @@ def plugin_loaded():
 def load_deltas():
 	global delta_up, delta_down, delta_left, delta_right
 
-	delta_default = settings.get("delta_default", 0.1)
-	delta_up = settings.get("delta_up", delta_default)
-	delta_down = settings.get("delta_down", delta_default)
-	delta_left = settings.get("delta_left", delta_default)
-	delta_right = settings.get("delta_right", delta_default)
+	delta_default = settings.get("resize_delta_default", 0.01)
+	delta_up = settings.get("resize_delta_up", delta_default)
+	delta_down = settings.get("resize_delta_down", delta_default)
+	delta_left = settings.get("resize_delta_left", delta_default)
+	delta_right = settings.get("resize_delta_right", delta_default)
 
 XMIN, YMIN, XMAX, YMAX = range(4)
 

--- a/resize_active_group.sublime-settings
+++ b/resize_active_group.sublime-settings
@@ -6,11 +6,11 @@
 {
     // The delta value used when resizing the active group. It is set to 0.01 (1 %) by default.
     // It does not make much sense for it to have a higher value than 0.5 (50 %).
-    "delta_default": 0.01,
+    "resize_delta_default": 0.01
 
     // Optionally, comment in the lines below if you'd want per-direction resize of the groups.
-    // "delta_up": 0.1,
-    // "delta_down": 0.1,
-    // "delta_left": 0.1,
-    // "delta_right": 0.1
+    // "resize_delta_up": 0.1,
+    // "resize_delta_down": 0.1,
+    // "resize_delta_left": 0.1,
+    // "resize_delta_right": 0.1
 }

--- a/resize_active_group.sublime-settings
+++ b/resize_active_group.sublime-settings
@@ -1,0 +1,16 @@
+// Resize Group With Keyboard default settings.
+//
+// In order to tweak the settings, you should NOT edit this file, but instead edit
+// the user-specific, empty-by-default version under
+// "Preferences / Package Settings / Resize Group With Keyboard / Settings - User".
+{
+    // The delta value used when resizing the active group. It is set to 0.01 (1 %) by default.
+    // It does not make much sense for it to have a higher value than 0.5 (50 %).
+    "delta_default": 0.01,
+
+    // Optionally, comment in the lines below if you'd want per-direction resize of the groups.
+    // "delta_up": 0.1,
+    // "delta_down": 0.1,
+    // "delta_left": 0.1,
+    // "delta_right": 0.1
+}


### PR DESCRIPTION
I've been using this plugin for a while, but I have hard coded the different deltas to other values than the default ones. However, I decided to modify the plugin to make the resize delta accessible via a settings-file and make a pull request out of it.
- The plugin now reads a settings-file upon being loaded, with settings for a default resize delta and per-direcetion resize deltas.
- A menu entry under `Preferences` have been added for the `Resize Group With Keyboard` plugin.
- The Readme has been updated with explanation of the different settings.
